### PR TITLE
feat: cpp sdk - default config ports

### DIFF
--- a/callouts/cpp/README.md
+++ b/callouts/cpp/README.md
@@ -101,18 +101,31 @@ To run the unit tests, use the following command from the project root:
 bazel test --test_summary=detailed --config=clang //...
 ```
 
+## Runtime Configuration
+
+Configure the server using these command line flags:
+
+```sh
+./custom_callout_server_cpp \
+  --server_address=0.0.0.0:8443 \  # Secure endpoint (default: 0.0.0.0:443)
+  --health_check_port=8080 \       # Health check port (default: 80)
+  --key_path=/path/to/key.pem \    # SSL private key (default: ssl_creds/privatekey.pem)
+  --cert_path=/path/to/cert.pem    # SSL certificate (default: ssl_creds/chain.pem)
+```
+
 ## Developing Callouts
 
 This repository provides the following files to be extended to fit the needs of the user:
 
-[CalloutServer](./service/callout_server.h): Baseline service callout server.
+[CalloutServer](./service/callout_server.h): Baseline service callout server with dual endpoints (secure/insecure) and health check service.
 
 ### Making a New Server
 
-The provided code defines a basic `CalloutServer` class that implements
-the `ExternalProcessor::Service` interface.
-This server listens for gRPC requests from Envoy and processes them.
-To create a new server, you'll generally extend this class.
+The provided `CalloutServer` class implements the `ExternalProcessor::Service` interface with:
+- Secure (TLS) endpoint on port 443
+- Insecure (plaintext) endpoint on port 8080
+- HTTP health check on port 80
+- Configurable via command line flags
 
 ### Extend the CalloutServer
 
@@ -153,14 +166,16 @@ void OnRequestHeader(ProcessingRequest* request,
 
 ### Run the Server
 
-To start your custom server, you'll need to create an instance of your custom class
-and use a `grpc::ServerBuilder` to build and start the gRPC server.
+The server automatically handles:
+- Dual gRPC endpoints (secure/insecure)
+- Health check service
+- Command line configuration
 
-To make this process easier there is already a [main.cc](./service/main.cc) file which
-serve this purpose.
-
-This _main_ file, in addition to initializing the gRPC server, also configures
-command line arguments and initializes the HTTP health check.
+Example minimal setup:
+```c++
+auto config = CalloutServer::DefaultConfig();
+CalloutServer::RunServers(config);
+```
 
 An example of how this file can be used together with your custom service
 implementation can be found in this bazel [BUILD](./examples/basic/BUILD) file

--- a/callouts/cpp/README.md
+++ b/callouts/cpp/README.md
@@ -27,11 +27,39 @@ The minimal operation of this C++ based ext_proc server requires Bazel, Clang an
 
 You can run the examples directly with Bazel and Clang without using Docker.
 
+### Install Clang
+
+#### For Linux
+
+```sh
+sudo apt-get install clang
+```
+
+#### For macOS
+
+```
+brew install llvm
+```
+
 ### Install Bazel
 
 The recommended way to install Bazel is from the
 [Bazelisk](https://bazel.build/install/bazelisk#installing_bazel) which can manage different Bazel
 versions.
+
+#### For Linux/macOS
+
+```sh
+npm install -g @bazel/bazelisk
+```
+
+### Verify Installation
+
+```
+clang --version
+bazel --version
+docker --version
+```
 
 ### Set Environment Variable
 
@@ -93,6 +121,21 @@ Running from the [./config](./config)
 EXAMPLE_TYPE=basic docker-compose up
 ```
 
+## Running the without Docker
+
+### Set Example Type:
+
+```
+export EXAMPLE_TYPE=basic  # Options: basic, jwt_auth, redirect
+```
+
+### Build and Run:
+
+```
+bazel build --config=clang //examples/${EXAMPLE_TYPE}:custom_callout_server_cpp
+./bazel-bin/examples/${EXAMPLE_TYPE}/custom_callout_server_cpp
+```
+
 ## Running Tests
 
 To run the unit tests, use the following command from the project root:
@@ -111,6 +154,15 @@ Configure the server using these command line flags:
   --health_check_port=8080 \       # Health check port (default: 80)
   --key_path=/path/to/key.pem \    # SSL private key (default: ssl_creds/privatekey.pem)
   --cert_path=/path/to/cert.pem    # SSL certificate (default: ssl_creds/chain.pem)
+```
+
+### Custom Ports and SSL
+
+```
+docker run -p 8443:8443 -p 8080:8080 \
+  -e SERVER_ADDRESS=0.0.0.0:8443 \
+  -v /path/to/ssl:/ssl_creds \
+  service-callout-cpp:${EXAMPLE_TYPE}
 ```
 
 ## Developing Callouts

--- a/callouts/cpp/config/Dockerfile
+++ b/callouts/cpp/config/Dockerfile
@@ -12,52 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Global build type to be used on the stages
 ARG EXAMPLE_TYPE=basic
 
-# Use the Debian 9 Clang base image for both stages
-FROM marketplace.gcr.io/google/debian12 AS builder
+FROM debian:12-slim AS builder
 
-# Install bazelisk
-RUN apt-get update \
-&& apt-get install -y wget \
-&& wget https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64 \
-&& chmod +x bazelisk-linux-amd64 \
-&& mv bazelisk-linux-amd64 /usr/local/bin/bazel
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    wget clang g++ git python3 python3-pip \
+    libssl-dev libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install Clang
-RUN apt-get install -y clang
+# Install Bazelisk
+RUN wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+    && chmod +x /usr/local/bin/bazel
 
-# Set the compiler env var for bazel
-ENV CC /usr/bin/clang
-
-#Set environment variable for runtine
-ARG EXAMPLE_TYPE
-ENV EXAMPLE_TYPE=${EXAMPLE_TYPE}
-
-# Set the Current Working Directory inside the container
 WORKDIR /app
-
-# Copy the source from the current directory to the Working Directory inside the container
 COPY . .
 
-# Build the C++ app
-RUN bazel build --config=clang //examples/${EXAMPLE_TYPE}:custom_callout_server_cpp
+# Build with explicit output path
+RUN EXAMPLE_TYPE=${EXAMPLE_TYPE:-basic} && \
+    bazel build --config=clang --cxxopt='-std=c++17' //examples/${EXAMPLE_TYPE}:custom_callout_server_cpp && \
+    mkdir -p /app/build_output && \
+    cp bazel-bin/examples/${EXAMPLE_TYPE}/custom_callout_server_cpp /app/build_output/
 
-# Use the same image for the final stage
-FROM marketplace.gcr.io/google/debian12
+# Runtime image
+FROM debian:12-slim
 
-ARG EXAMPLE_TYPE
-ENV EXAMPLE_TYPE=${EXAMPLE_TYPE}
+RUN apt-get update && apt-get install -y \
+    libssl3 libboost-system1.74.0 \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy the Pre-built binary file from the previous stage
-COPY --from=builder /app/bazel-bin .
+# Copy artifacts from builder
+COPY --from=builder /app/build_output/custom_callout_server_cpp /app/
+COPY --from=builder /app/ssl_creds /app/ssl_creds
 
-# Copy SSL certificates
-COPY ssl_creds ./ssl_creds
-
-# Expose port 8443, 8181, and 8000
-EXPOSE 8443 8181 8000
-
-# Command to run the executable
-CMD "./examples/${EXAMPLE_TYPE}/custom_callout_server_cpp"
+EXPOSE 443 8080 80
+WORKDIR /app
+CMD ["./custom_callout_server_cpp"]

--- a/callouts/cpp/config/docker-compose.yml
+++ b/callouts/cpp/config/docker-compose.yml
@@ -17,16 +17,15 @@ version: '3.8'
 services:
   app:
     build:
-      context: ../  # Adjust the context to the correct path if needed
+      context: ../
       dockerfile: config/Dockerfile
       args:
-        EXAMPLE_TYPE: ${EXAMPLE_TYPE}
+        EXAMPLE_TYPE: ${EXAMPLE_TYPE:-basic}
     ports:
-      - "8443:8443"
+      - "443:443"
       - "8080:8080"
-      - "8000:8000"
-    environment:
-      - EXAMPLE_TYPE=${EXAMPLE_TYPE}
+      - "80:80"
     volumes:
-      - .:/app
-    command: "./examples/${EXAMPLE_TYPE}/custom_callout_server_cpp"
+      - ../ssl_creds:/app/ssl_creds
+    environment:
+      - EXAMPLE_TYPE=${EXAMPLE_TYPE:-basic}

--- a/callouts/cpp/config/docker-compose.yml
+++ b/callouts/cpp/config/docker-compose.yml
@@ -25,7 +25,5 @@ services:
       - "443:443"
       - "8080:8080"
       - "80:80"
-    volumes:
-      - ../ssl_creds:/app/ssl_creds
     environment:
       - EXAMPLE_TYPE=${EXAMPLE_TYPE:-basic}

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -38,7 +38,7 @@ class BasicServerTest : public testing::Test {
     config_.cert_path = "";
 
     server_thread_ = std::thread([this]() {
-      CalloutServer::RunServers<CustomCalloutServer>(config_);
+      CalloutServer::RunServers(config_);
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -45,12 +45,10 @@ class BasicServerTest : public testing::Test {
 
   void TearDown() override {
     CalloutServer::Shutdown();
+    CalloutServer::WaitForCompletion();
+    
     if (server_thread_.joinable()) {
-      try {
         server_thread_.join();
-      } catch (const std::system_error& e) {
-        LOG(ERROR) << "Thread join error: " << e.what();
-      }
     }
   }
 

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -30,20 +30,22 @@ using google::protobuf::util::MessageDifferencer;
 
 class BasicServerTest : public testing::Test {
  protected:
-  void SetUp() override {
+ void SetUp() override {
     config_ = CalloutServer::DefaultConfig();
     config_.enable_insecure = true;
-    config_.insecure_address = "0.0.0.0:8080";
-    config_.health_check_address = "0.0.0.0:80";
+    config_.insecure_address = "0.0.0.0:8181";
+    config_.health_check_address = "0.0.0.0:8081";
     
-    // Start server in separate thread
     server_thread_ = std::thread([this]() {
       CalloutServer::RunServers(config_);
     });
   }
 
   void TearDown() override {
-    server_thread_.join();
+    CalloutServer::Shutdown();
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
   }
 
   CalloutServer::ServerConfig config_;

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -30,17 +30,16 @@ using google::protobuf::util::MessageDifferencer;
 
 class BasicServerTest : public testing::Test {
  protected:
- void SetUp() override {
+  void SetUp() override {
     config_ = CalloutServer::DefaultConfig();
-    config_.enable_insecure = true;
-    config_.insecure_address = "0.0.0.0:8181";
+    config_.enable_plaintext = true;
+    config_.plaintext_address = "0.0.0.0:8181";
     config_.health_check_address = "0.0.0.0:8081";
     config_.key_path = "";
     config_.cert_path = "";
-    
-    server_thread_ = std::thread([this]() {
-      CalloutServer::RunServers(config_);
-    });
+
+    server_thread_ = std::thread([this]() { CalloutServer::RunServers(config_); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
   void TearDown() override {

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -35,6 +35,8 @@ class BasicServerTest : public testing::Test {
     config_.enable_insecure = true;
     config_.insecure_address = "0.0.0.0:8181";
     config_.health_check_address = "0.0.0.0:8081";
+    config_.key_path = "";
+    config_.cert_path = "";
     
     server_thread_ = std::thread([this]() {
       CalloutServer::RunServers(config_);
@@ -44,7 +46,11 @@ class BasicServerTest : public testing::Test {
   void TearDown() override {
     CalloutServer::Shutdown();
     if (server_thread_.joinable()) {
-      server_thread_.join();
+      try {
+        server_thread_.join();
+      } catch (const std::system_error& e) {
+        LOG(ERROR) << "Thread join error: " << e.what();
+      }
     }
   }
 

--- a/callouts/cpp/examples/basic/custom_callout_server_test.cc
+++ b/callouts/cpp/examples/basic/custom_callout_server_test.cc
@@ -15,7 +15,6 @@
 #include "custom_callout_server.h"
 #include "service/callout_server.h"
 
-#include <google/protobuf/arena.h>
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/service/ext_proc/v3/external_processor.pb.h"
 #include "google/protobuf/util/message_differencer.h"
@@ -38,7 +37,9 @@ class BasicServerTest : public testing::Test {
     config_.key_path = "";
     config_.cert_path = "";
 
-    server_thread_ = std::thread([this]() { CalloutServer::RunServers(config_); });
+    server_thread_ = std::thread([this]() {
+      CalloutServer::RunServers<CustomCalloutServer>(config_);
+    });
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
@@ -47,136 +48,116 @@ class BasicServerTest : public testing::Test {
     CalloutServer::WaitForCompletion();
     
     if (server_thread_.joinable()) {
-        server_thread_.join();
+      server_thread_.join();
     }
   }
 
   CalloutServer::ServerConfig config_;
   std::thread server_thread_;
-  CustomCalloutServer service_;
 };
 
 TEST_F(BasicServerTest, OnRequestHeader) {
-// Initialize the service paremeters
-  google::protobuf::Arena arena;
-  ProcessingRequest* request =
-      google::protobuf::Arena::Create<ProcessingRequest>(&arena);
-  ProcessingResponse* response =
-      google::protobuf::Arena::Create<ProcessingResponse>(&arena);
+  ProcessingRequest request;
+  request.mutable_request_headers();
+  ProcessingResponse response;
+  CustomCalloutServer service;
+  
+  service.OnRequestHeader(&request, &response);
 
-  // Call the OnRequestHeader method
-  service_.OnRequestHeader(request, response);
-
-  // Define the expected response
   ProcessingResponse expected_response;
-  HeaderMutation* header_mutation = expected_response.mutable_request_headers()
-                                        ->mutable_response()
-                                        ->mutable_header_mutation();
-
-  HeaderValue* header = header_mutation->add_set_headers()->mutable_header();
-  header->set_key("add-header-request");
-  header->set_value("Value-request");
-
-  HeaderValueOption* header_option = header_mutation->add_set_headers();
-  header_option->set_append_action(
-      HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
-  HeaderValue* new_header = header_option->mutable_header();
-  new_header->set_key("replace-header-request");
+  auto* headers_mutation = expected_response.mutable_request_headers()
+                              ->mutable_response()
+                              ->mutable_header_mutation();
+  
+  // Add header
+  auto* new_header = headers_mutation->add_set_headers()->mutable_header();
+  new_header->set_key("add-header-request");
   new_header->set_value("Value-request");
+  
+  // Replace header
+  auto* replace_header = headers_mutation->add_set_headers();
+  replace_header->set_append_action(
+      HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+  replace_header->mutable_header()->set_key("replace-header-request");
+  replace_header->mutable_header()->set_value("Value-request");
 
-  // Compare the proto messages
   MessageDifferencer differencer;
-  std::string diff_string;
-  differencer.ReportDifferencesToString(&diff_string);
-  EXPECT_TRUE(differencer.Compare(*response, expected_response))
-      << "Responses should be equal. Difference: " << diff_string;
+  std::string diff;
+  differencer.ReportDifferencesToString(&diff);
+  EXPECT_TRUE(differencer.Compare(response, expected_response))
+      << "Differences found:\n" << diff;
 }
 
 TEST_F(BasicServerTest, OnResponseHeader) {
-  // Initialize the service paremeters
-  google::protobuf::Arena arena;
-  ProcessingRequest* request =
-      google::protobuf::Arena::Create<ProcessingRequest>(&arena);
-  ProcessingResponse* response =
-      google::protobuf::Arena::Create<ProcessingResponse>(&arena);
+  ProcessingRequest request;
+  request.mutable_response_headers();
+  ProcessingResponse response;
+  CustomCalloutServer service;
+  
+  service.OnResponseHeader(&request, &response);
 
-  // Call the OnResponseHeader method
-  service_.OnResponseHeader(request, response);
-
-  // Define the expected response
   ProcessingResponse expected_response;
-  HeaderMutation* header_mutation =
-      expected_response.mutable_response_headers()
-          ->mutable_response()
-          ->mutable_header_mutation();
-
-  HeaderValue* header = header_mutation->add_set_headers()->mutable_header();
-  header->set_key("add-header-response");
-  header->set_value("Value-response");
-
-  HeaderValueOption* header_option = header_mutation->add_set_headers();
-  header_option->set_append_action(
-      HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
-  HeaderValue* new_header = header_option->mutable_header();
-  new_header->set_key("replace-header-response");
+  auto* headers_mutation = expected_response.mutable_response_headers()
+                               ->mutable_response()
+                               ->mutable_header_mutation();
+  
+  // Add header
+  auto* new_header = headers_mutation->add_set_headers()->mutable_header();
+  new_header->set_key("add-header-response");
   new_header->set_value("Value-response");
+  
+  // Replace header
+  auto* replace_header = headers_mutation->add_set_headers();
+  replace_header->set_append_action(
+      HeaderValueOption::OVERWRITE_IF_EXISTS_OR_ADD);
+  replace_header->mutable_header()->set_key("replace-header-response");
+  replace_header->mutable_header()->set_value("Value-response");
 
-  // Compare the proto messages
   MessageDifferencer differencer;
-  std::string diff_string;
-  differencer.ReportDifferencesToString(&diff_string);
-  EXPECT_TRUE(differencer.Compare(*response, expected_response))
-      << "Responses should be equal. Difference: " << diff_string;
+  std::string diff;
+  differencer.ReportDifferencesToString(&diff);
+  EXPECT_TRUE(differencer.Compare(response, expected_response))
+      << "Differences found:\n" << diff;
 }
 
 TEST_F(BasicServerTest, OnRequestBody) {
-  // Initialize the service paremeters
-  google::protobuf::Arena arena;
-  ProcessingRequest* request =
-      google::protobuf::Arena::Create<ProcessingRequest>(&arena);
-  ProcessingResponse* response =
-      google::protobuf::Arena::Create<ProcessingResponse>(&arena);
+  ProcessingRequest request;
+  request.mutable_request_body();
+  ProcessingResponse response;
+  CustomCalloutServer service;
+  
+  service.OnRequestBody(&request, &response);
 
-  // Call the OnRequestBody method
-  service_.OnRequestBody(request, response);
-
-  // Define the expected response
   ProcessingResponse expected_response;
   expected_response.mutable_request_body()
       ->mutable_response()
       ->mutable_body_mutation()
       ->set_body("new-body-request");
 
-  // Compare the proto messages
   MessageDifferencer differencer;
-  std::string diff_string;
-  differencer.ReportDifferencesToString(&diff_string);
-  EXPECT_TRUE(differencer.Compare(*response, expected_response))
-      << "Responses should be equal. Difference: " << diff_string;
+  std::string diff;
+  differencer.ReportDifferencesToString(&diff);
+  EXPECT_TRUE(differencer.Compare(response, expected_response))
+      << "Differences found:\n" << diff;
 }
 
 TEST_F(BasicServerTest, OnResponseBody) {
-  // Initialize the service paremeters
-  google::protobuf::Arena arena;
-  ProcessingRequest* request =
-      google::protobuf::Arena::Create<ProcessingRequest>(&arena);
-  ProcessingResponse* response =
-      google::protobuf::Arena::Create<ProcessingResponse>(&arena);
+  ProcessingRequest request;
+  request.mutable_response_body();
+  ProcessingResponse response;
+  CustomCalloutServer service;
+  
+  service.OnResponseBody(&request, &response);
 
-  // Call the OnResponseBody method
-  service_.OnResponseBody(request, response);
-
-  // Define the expected response
   ProcessingResponse expected_response;
   expected_response.mutable_response_body()
       ->mutable_response()
       ->mutable_body_mutation()
       ->set_body("new-body-response");
 
-  // Compare the proto messages
   MessageDifferencer differencer;
-  std::string diff_string;
-  differencer.ReportDifferencesToString(&diff_string);
-  EXPECT_TRUE(differencer.Compare(*response, expected_response))
-      << "Responses should be equal. Difference: " << diff_string;
+  std::string diff;
+  differencer.ReportDifferencesToString(&diff);
+  EXPECT_TRUE(differencer.Compare(response, expected_response))
+      << "Differences found:\n" << diff;
 }

--- a/callouts/cpp/service/callout_server.h
+++ b/callouts/cpp/service/callout_server.h
@@ -166,13 +166,12 @@ class CalloutServer : public ExternalProcessor::Service {
     return grpc::SslServerCredentials(ssl_options);
   }
 
-  template <typename T>
   static bool RunServers(const ServerConfig& config = ServerConfig{}) {
     std::unique_lock<std::mutex> lock(server_mutex_);
     if (config.enable_plaintext && !plaintext_server_) {
       plaintext_thread_ = std::thread([config]() {
         std::unique_ptr<grpc::Server> local_server;
-        auto service = std::make_unique<T>();
+        auto service = std::make_unique<CalloutServer>();
         {
           grpc::ServerBuilder builder;
           builder.AddListeningPort(config.plaintext_address,


### PR DESCRIPTION
**Updating `main.cc `and `callout_server.h`:**

Plain text port uses 8080 by default.
Plain text server is ENABLED by default.

Health check port uses 80 by default.
Health check is ENABLED by default.

The secure port we need to use 443 by default.

**Updated Dockerfile:**

Slimmer image (`debian:12-slim`)
Explicit deps + cleanup
Fixed C++17 flag
Better artifact handling

**Updated docker-compose.yml:**

Standard ports (443, 80)
Fallback for `EXAMPLE_TYPE`
Removed redundant `command:`
Safer volume mounts

**Updated README.md file.** 

![Captura de tela de 2025-04-01 12-46-07](https://github.com/user-attachments/assets/70ab6331-d726-4add-b104-d1298c4a0f7e)
