### PR TITLE
feat: Add a rust plugin to include a custom error page with the traceid

### DIFF
--- a/plugins/samples/error_page_with_traceid/BUILD
+++ b/plugins/samples/error_page_with_traceid/BUILD
@@ -1,0 +1,20 @@
+load("//:plugins.bzl", "proxy_wasm_plugin_rust", "proxy_wasm_tests")
+
+licenses(["notice"])  # Apache 2
+
+proxy_wasm_plugin_rust(
+    name = "plugin_rust.wasm",
+    srcs = ["plugin.rs"],
+    deps = [
+        "//bazel/cargo/remote:log",
+        "//bazel/cargo/remote:proxy-wasm",
+    ],
+)
+
+proxy_wasm_tests(
+    name = "tests",
+    plugins = [
+        ":plugin_rust.wasm",
+    ],
+    tests = ":tests.textpb",
+)

--- a/plugins/samples/error_page_with_traceid/plugin.rs
+++ b/plugins/samples/error_page_with_traceid/plugin.rs
@@ -1,0 +1,124 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START serviceextensions_plugin_error_page_with_traceid]
+use proxy_wasm::traits::*;
+use proxy_wasm::types::*;
+
+// Custom HTML template for error pages
+const ERROR_TEMPLATE: &str = r#"
+<html>
+<head>
+  <title>Error {STATUS_CODE}</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    .container { max-width: 800px; margin: 0 auto; }
+    .trace-id { 
+      background-color: #f5f5f5; 
+      padding: 1rem; 
+      font-family: monospace;
+      word-break: break-all;
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Error {STATUS_CODE}</h1>
+    <p>We're sorry, something went wrong with your request.</p>
+    
+    <div class="trace-id">
+      <strong>Trace ID:</strong> {TRACE_ID}
+    </div>
+    
+    <p>Please provide this trace ID to support for assistance.</p>
+  </div>
+</body>
+</html>
+"#;
+
+proxy_wasm::main! {{
+    proxy_wasm::set_log_level(LogLevel::Debug);
+    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(ErrorPageWithTraceId::default()) });
+}}
+
+struct ErrorPageWithTraceId {
+    trace_id: String,
+}
+
+impl Default for ErrorPageWithTraceId {
+    fn default() -> Self {
+        Self {
+            trace_id: "not-available".to_string(),
+        }
+    }
+}
+
+impl Context for ErrorPageWithTraceId {}
+
+impl HttpContext for ErrorPageWithTraceId {
+    fn on_http_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
+        self.trace_id = self.extract_trace_id();
+        log::debug!("Captured trace ID: {}", self.trace_id);
+        Action::Continue
+    }
+
+    fn on_http_response_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
+        if let Some(status) = self.get_http_response_header(":status") {
+            if let Ok(status_code) = status.parse::<u16>() {
+                // Only handle error status codes (4xx and 5xx)
+                if status_code >= 400 {
+                    let error_page = ERROR_TEMPLATE
+                        .replace("{STATUS_CODE}", &status)
+                        .replace("{TRACE_ID}", &self.trace_id);
+
+                    // Convert u16 to u32 for status code
+                    self.send_http_response(
+                        status_code as u32,
+                        vec![("Content-Type", "text/html; charset=utf-8")],
+                        Some(error_page.as_bytes()),
+                    );
+                    return Action::Pause;
+                }
+            }
+        }
+        Action::Continue
+    }
+}
+
+impl ErrorPageWithTraceId {
+    fn extract_trace_id(&self) -> String {
+        // Try standard Google Cloud trace header first
+        if let Some(trace_header) = self.get_http_request_header("x-cloud-trace-context") {
+            // Format: TRACE_ID/SPAN_ID;o=TRACE_TRUE
+            if let Some(slash_pos) = trace_header.find('/') {
+                return trace_header[..slash_pos].to_string();
+            }
+            return trace_header;
+        }
+
+        // Try W3C Trace Context standard
+        if let Some(w3c_trace) = self.get_http_request_header("traceparent") {
+            // Format: version-trace_id-parent_id-flags
+            let parts: Vec<&str> = w3c_trace.split('-').collect();
+            if parts.len() >= 4 && parts[1].len() == 32 {
+                return parts[1].to_string(); // Return trace ID (second part)
+            }
+            return "invalid-trace-format".to_string();
+        }
+
+        "not-available".to_string()
+    }
+}
+// [END serviceextensions_plugin_error_page_with_traceid]

--- a/plugins/samples/error_page_with_traceid/tests.textpb
+++ b/plugins/samples/error_page_with_traceid/tests.textpb
@@ -1,0 +1,95 @@
+# Test specific status codes (e.g., 502 Bad Gateway)
+test {
+  name: "ErrorPage502Status"
+  request_headers {
+    input {
+      header { key: "x-cloud-trace-context" value: "abcdef123456789" }
+    }
+  }
+  response_headers {
+    input {
+      header { key: ":status" value: "502" }
+    }
+    result {
+      immediate { http_status: 502 }
+      body { regex: "(?s).*Error 502.*abcdef123456789.*" }
+    }
+  }
+}
+
+# Test that 2xx responses don't trigger custom error page
+test {
+  name: "NoErrorPageFor200"
+  request_headers {
+    input {
+      header { key: "x-cloud-trace-context" value: "abcdef123456789" }
+    }
+  }
+  response_headers {
+    input {
+      header { key: ":status" value: "200" }
+    }
+    # For normal responses, we expect the filter to allow the request to continue
+    # without modification, so no explicit result needed
+  }
+}
+
+# Test with additional response headers
+test {
+  name: "ErrorPagePreservesContentType"
+  request_headers {
+    input {
+      header { key: "traceparent" value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" }
+    }
+  }
+  response_headers {
+    input {
+      header { key: ":status" value: "500" }
+      header { key: "content-type" value: "application/json" }
+      header { key: "x-custom-header" value: "test-value" }
+    }
+    result {
+      immediate { http_status: 500 }
+      body { regex: "(?s).*Error 500.*4bf92f3577b34da6a3ce929d0e0e4736.*" }
+    }
+  }
+}
+
+# Test precedence when both trace headers are present
+test {
+  name: "MultipleDifferentTraceHeaders"
+  request_headers {
+    input {
+      header { key: "x-cloud-trace-context" value: "cloud-trace-id/1" }
+      header { key: "traceparent" value: "00-w3c-trace-id-00f067aa0ba902b7-01" }
+    }
+  }
+  response_headers {
+    input {
+      header { key: ":status" value: "429" }
+    }
+    result {
+      immediate { http_status: 429 }
+      body { regex: "(?s).*cloud-trace-id.*" }
+    }
+  }
+}
+
+# Test different Google Cloud Trace formats
+test {
+  name: "GoogleTraceWithoutSpan"
+  request_headers {
+    input {
+      header { key: "x-cloud-trace-context" value: "trace-without-span-id" }
+    }
+  }
+  response_headers {
+    input {
+      header { key: ":status" value: "500" }
+    }
+    result {
+      immediate { http_status: 500 }
+      body { regex: "(?s).*trace-without-span-id.*" }
+    }
+  }
+}


### PR DESCRIPTION
Adding a plugin in rust that surfaces traceID in custom error pages.
We're checking for both Google Cloud trace header and W3C header.
Also adding a BUILD file and a tests.textpb file.